### PR TITLE
the procedure in BabelNet-API-4.0.1 is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ Press `Ctrl+C` to terminate the server.
 
 ### Query using a web browser (or curl)
 
-- Text to BabelNet (noun): [localhost:9000/text/en/mouse](http://localhost:9000/text/en/mouse) (change to your language and keyword).
+- Text to BabelNet (noun): [localhost:9000/text/en/mouse/](http://localhost:9000/text/en/mouse) (change to your language and keyword).
 - Text to BabelNet (all POS): [localhost:9000/text/en/find/v](http://localhost:9000/text/en/find/v) (change to your language, keyword and POS).
-- WordNet to BabelNet: [localhost:9000/wordnet/15203791n](http://localhost:9000/wordnet/15203791n) (change to your offset).
+- not work????WordNet to BabelNet: [localhost:9000/wordnet/15203791n](http://localhost:9000/wordnet/15203791n) (change to your offset).
 - Wikipedia to BabelNet: [localhost:9000/wikipedia/Mars/n](http://localhost:9000/wikipedia/Mars/n) 
 (plugin your page, the second place is POS, being one of these values: 
 `n` (noun), `v` (verb), `r` (adverb), `a` (adjective)).
 - Related synsets: [localhost:9000/synset/bn:00000002n/related](http://localhost:9000/synset/bn:00000002n/related) (change to your offset).
 - Senses: [localhost:9000/synset/bn:00000002n/senses/en](http://localhost:9000/synset/bn:00000002n/senses/en) (change to your offset, language code is optional).
-- DBpedia URIs: [localhost:9000/synset/bn:00000002n/dbpedia_uri/en](http://localhost:9000/synset/bn:00000002n/dbpedia_uri/en) (change to your offset, language code is optional).
+- not work????DBpedia URIs: [localhost:9000/synset/bn:00000002n/dbpedia_uri/en](http://localhost:9000/synset/bn:00000002n/dbpedia_uri/en) (change to your offset, language code is optional).
 
 ### Query using Python
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ the beginning.
 ### Install BabelNet API
 
 1. Change directory into BabelNet-API-4.0.1
-2. Compile: `ant -f build.xml`
-3. Install into local Maven repository:
+2. Install into local Maven repository:
  
  `mvn install:install-file -Dfile=babelnet-api-4.0.1.jar -DgroupId=it.uniroma1.lcl -DartifactId=babelnet -Dversion=4.0.1 -Dpackaging=jar -DgeneratePom=true`
  
+ `mvn install:install-file -Dfile=lib/lcl-jlt-2.4.jar -DgroupId=it.uniroma1.lcl -DartifactId=jlt -Dversion=2.4 -Dpackaging=jar -DgeneratePom=true`
+ 
  `mvn install:install-file -Dfile=lib/babelscape-data-commons-1.0.jar -DgroupId=com.babelscape -DartifactId=commons -Dversion=1.0.0 -Dpackaging=jar -DgeneratePom=true`
 
-4. Make sure that the `babelnet.dir` property in 
+3. Make sure that the `babelnet.dir` property in 
 `config/babelnet.var.properties` point to the directory 
 where BabelNet data lives. 
 


### PR DESCRIPTION
In my environment, 
build.xml is not found.
and 
mvn install:install-file -Dfile=lib/lcl-jlt-2.4.jar -DgroupId=it.uniroma1.lcl -DartifactId=jlt -Dversion=2.4 -Dpackaging=jar -DgeneratePom=true is needed

If your environment is different from mine, please reject.